### PR TITLE
Update .gitmodules to point to https links instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "hip"]
 	path = hip
-	url = git@github.com:HIP-infrastructure/hip
+	url = https://github.com/HIP-infrastructure/hip
 [submodule "gateway"]
 	path = gateway
-	url = git@github.com:HIP-infrastructure/gateway
+	url = https://github.com/HIP-infrastructure/gateway
 [submodule "ghostfs"]
 	path = ghostfs
-	url = git@github.com:HIP-infrastructure/ghostfs.git
+	url = https://github.com/HIP-infrastructure/ghostfs


### PR DESCRIPTION
The --recurse-submodules should be used with https since these are public repos and we cannot expect someone to have a github account configured with the public key of the machine where they clone a project..